### PR TITLE
Add seed

### DIFF
--- a/cosmogrb/instruments/gbm/gbm_grb.py
+++ b/cosmogrb/instruments/gbm/gbm_grb.py
@@ -1,4 +1,6 @@
 import logging
+import numpy as np
+from time import time
 
 from cosmogrb.grb import GRB, SourceParameter
 from cosmogrb.instruments.gbm.gbm_background import GBMBackground
@@ -81,7 +83,15 @@ class GBMGRB(GRB):
 
     def _setup(self):
 
+        # set a random seed to make sure that all detectors are set at same 
+        # same random time in orbit = same location in orbit for one GRB
+
+        random_seed = int(str(int(time()))[::-1])
+
         for det in self._gbm_detectors:
+
+            rng = np.random.default_rng(seed=random_seed)
+
             if det[0] == "b":
 
                 logger.debug(
@@ -89,7 +99,7 @@ class GBMGRB(GRB):
                 )
 
                 rsp = BGOResponse(
-                    det, self.ra, self.dec, save=False, name=self.name
+                    det, self.ra, self.dec, save=False, name=self.name, rng=rng
                 )
 
             else:
@@ -99,7 +109,7 @@ class GBMGRB(GRB):
                 )
 
                 rsp = NaIResponse(
-                    det, self.ra, self.dec, save=False, name=self.name
+                    det, self.ra, self.dec, save=False, name=self.name, rng=rng
                 )
 
             self._add_response(det, rsp)

--- a/cosmogrb/instruments/gbm/gbm_orbit.py
+++ b/cosmogrb/instruments/gbm/gbm_orbit.py
@@ -48,10 +48,13 @@ class GBMOrbit(object):
         """
         return self._T0
 
-    @property
-    def random_time(self):
+    def random_time(self,rng):
 
-        time = np.random.uniform(0, self._maximum_time)
+        # sample from chosen random number generator 
+        # (same for all detectors for one GRB)
+
+        time = rng.uniform(0, self._maximum_time)
+
         self._used_times.append(time)
 
         return time

--- a/cosmogrb/instruments/gbm/gbm_response.py
+++ b/cosmogrb/instruments/gbm/gbm_response.py
@@ -31,6 +31,7 @@ _det_translate = dict(
 )
 
 
+
 class GBMResponse(Response):
     def __init__(
         self,
@@ -39,6 +40,7 @@ class GBMResponse(Response):
         dec: float,
         radius: float,
         height: float,
+        rng: np.random._generator.Generator,
         save: float = False,
         name=None,
     ):
@@ -69,7 +71,10 @@ class GBMResponse(Response):
 
         if cosmogrb_config["gbm"]["orbit"]["use_random_time"]:
 
-            time: float = gbm_orbit.random_time
+            # make sure to put all detectors at same position 
+            # in orbit by passing random number generator
+
+            time: float = gbm_orbit.random_time(rng)
 
         else:
 
@@ -238,7 +243,7 @@ class GBMResponse(Response):
 
 
 class NaIResponse(GBMResponse):
-    def __init__(self, detector_name, ra, dec, save=False, name=None):
+    def __init__(self, detector_name, ra, dec, rng, save=False, name=None):
 
         super(NaIResponse, self).__init__(
             ra=ra,
@@ -246,13 +251,14 @@ class NaIResponse(GBMResponse):
             detector_name=detector_name,
             radius=0.5 * 12.7,
             height=1.27,
+            rng=rng,
             save=save,
             name=name,
         )
 
 
 class BGOResponse(GBMResponse):
-    def __init__(self, detector_name, ra, dec, save=False, name=None):
+    def __init__(self, detector_name, ra, dec, rng, save=False, name=None):
 
         super(BGOResponse, self).__init__(
             detector_name=detector_name,
@@ -260,6 +266,7 @@ class BGOResponse(GBMResponse):
             dec=dec,
             radius=0.5 * 12.7,
             height=12.7,
+            rng=rng,
             save=save,
             name=name,
         )

--- a/cosmogrb/instruments/gbm/gbm_universe.py
+++ b/cosmogrb/instruments/gbm/gbm_universe.py
@@ -23,7 +23,7 @@ class GBM_CPL_Universe(Universe):
 
         self._local_parameters["ep_start"] = self._population.ep
         self._local_parameters["alpha"] = self._population.alpha
-        self._local_parameters["peak_flux"] = self._population.fluxes_latent
+        self._local_parameters["peak_flux"] = self._population.fluxes.latent
         self._local_parameters["trise"] = self._population.trise
         self._local_parameters["tdecay"] = self._population.tdecay
         self._local_parameters["ep_tau"] = self._population.tau
@@ -123,7 +123,7 @@ class GBM_CPL_Constant_Universe(Universe):
 
         self._local_parameters["ep"] = self._population.ep
         self._local_parameters["alpha"] = self._population.alpha
-        self._local_parameters["peak_flux"] = self._population.fluxes_latent
+        self._local_parameters["peak_flux"] = self._population.fluxes.latent
 
     def _parameter_server_type(self, **kwargs):
 

--- a/cosmogrb/response/response.py
+++ b/cosmogrb/response/response.py
@@ -79,7 +79,7 @@ class Response(object):
 
         ea_curve = self._matrix.sum(axis=1)
 
-        # we just a numba jitclass to interpolate
+        # we use a numba jitclass to interpolate
         # we want this passable to functions locally
 
         self.effective_area = Interp1D(

--- a/cosmogrb/universe/survey.py
+++ b/cosmogrb/universe/survey.py
@@ -164,6 +164,28 @@ class Survey(collections.OrderedDict):
     def n_grbs(self) -> int:
         return self._n_grbs
 
+    @property
+    def names_detected_grbs(self):
+        return np.array(self._names)[self._detected]
+
+    @property
+    def names_grbs(self):
+        return np.array(self._names)
+
+    @property
+    def mask_detected_grbs(self):
+        #length of array = number of selected GRBs by popsynth
+        #True: GRB was detected, False: GRB was NOT detected
+        return self._detected
+
+    @property
+    def grb_save_files(self):
+        return np.array(self._grb_save_files)
+
+    @property
+    def files_detected_grbs(self):
+        return np.array(self._grb_save_files)[self._detected]
+
     def info(self) -> None:
         """
         display the information about the survey
@@ -225,7 +247,7 @@ class Survey(collections.OrderedDict):
                 _submit([grb_file, detector_type, kwargs])
 
         # the survey has now had its triggers run
-        # so lets flip its status and make sure that when
+        # so lets flip its status and make sure that
         # when we save it, we record the new status
 
         self._is_processed = True
@@ -301,7 +323,7 @@ class Survey(collections.OrderedDict):
     @classmethod
     def from_file(cls, file_name):
         """
-        create a universe
+        create a survey
 
         :param cls:
         :param file_name:

--- a/cosmogrb/universe/universe.py
+++ b/cosmogrb/universe/universe.py
@@ -15,7 +15,7 @@ logger = setup_logger(__name__)
 
 
 class Universe(object, metaclass=abc.ABCMeta):
-    """Documentation for Universe"""
+    """Generate a Universe of GRBs from a population file (output popsynth)"""
 
     def __init__(
         self,
@@ -30,9 +30,9 @@ class Universe(object, metaclass=abc.ABCMeta):
 
         :param population_file: a popsynth population file name
         :type population_file: str
-        :param grb_base_name:
+        :param grb_base_name: base name of saved GRB files
         :type grb_base_name: str
-        :param save_path:
+        :param save_path: path where GRB files are stored
         :type save_path: str
         :returns:
 


### PR DESCRIPTION
I found that the MET trigger_time differs for all detectors of one simulated GRB because every time, a new random number is generated in the function random_time of GBMOrbit. Instead, I believe, the detectors and thus the whole satellite should be placed at the same position, for the computation of the response for one GRB. I fixed it by giving always the same seed to the function.

I also added a few properties to the Survey class which I found helpful.